### PR TITLE
require pytest < 4.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest>=2.9.2
+pytest<4>=2.9.2
 tox>=2.3.1
 semantic_version>=2.6.0
 bumpversion==0.5.3


### PR DESCRIPTION
### What was wrong?
this line:
https://github.com/nucypher/py-solc/blob/master/tests/conftest.py#L86
fails because `get_marker` was removed in pytest>=4.0

### How was it fixed?
require purest<4.0



#### Cute Animal Picture
no.
> put a cute animal picture here.