### PR TITLE
support pytest > 4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest>=2.9.2
+pytest>4
 tox>=2.3.1
 semantic_version>=2.6.0
 bumpversion==0.5.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,6 @@ def INVALID_SOURCE(supported_solc_version):
 
 
 def pytest_runtest_setup(item):
-    if (item.get_marker('requires_standard_json') is not None and
+    if (item.get_closest_marker('requires_standard_json') is not None and
         not solc_supports_standard_json_interface()):
         pytest.skip('requires `--standard-json` support')


### PR DESCRIPTION
### What was wrong?

Running tests under pytest>4 was failing because get_marker was removed [as seen here](https://github.com/pytest-dev/pytest/issues/4608)

### How was it fixed?

replaced get_marker with `get_closest_marker` and updated requirements.


#### Cute Animal Picture
nah ah.
> put a cute animal picture here.